### PR TITLE
🩹 bump api version to 1.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,10 +5,11 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "workadventure-map-starter-kit",
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@workadventure/iframe-api-typings": "^1.2.1",
+        "@workadventure/iframe-api-typings": "^1.4.0",
         "eslint": "^7.24.0",
         "html-webpack-plugin": "^5.3.1",
         "ts-loader": "^8.1.0",
@@ -329,9 +330,9 @@
       "dev": true
     },
     "node_modules/@workadventure/iframe-api-typings": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@workadventure/iframe-api-typings/-/iframe-api-typings-1.2.1.tgz",
-      "integrity": "sha512-BZd+x5+iWHHfImwB1POEb/vH4+hpUX+YubwCUU0oLIhBLSquzNjH6PQich1VWvP62FO1d+ZEiVhV1iV8SXF6PA==",
+      "version": "1.4.12",
+      "resolved": "https://registry.npmjs.org/@workadventure/iframe-api-typings/-/iframe-api-typings-1.4.12.tgz",
+      "integrity": "sha512-GN2oFlgwK8PAv6Hz1EwmixmP12AUUz8Y0bQvXHsnbfpX2oOa/PUiYtFaNc1f1D4Emv88oRyw6NR+RouJM7XxXQ==",
       "dev": true
     },
     "node_modules/@xtuc/ieee754": {
@@ -7757,9 +7758,9 @@
       "dev": true
     },
     "@workadventure/iframe-api-typings": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@workadventure/iframe-api-typings/-/iframe-api-typings-1.2.1.tgz",
-      "integrity": "sha512-BZd+x5+iWHHfImwB1POEb/vH4+hpUX+YubwCUU0oLIhBLSquzNjH6PQich1VWvP62FO1d+ZEiVhV1iV8SXF6PA==",
+      "version": "1.4.12",
+      "resolved": "https://registry.npmjs.org/@workadventure/iframe-api-typings/-/iframe-api-typings-1.4.12.tgz",
+      "integrity": "sha512-GN2oFlgwK8PAv6Hz1EwmixmP12AUUz8Y0bQvXHsnbfpX2oOa/PUiYtFaNc1f1D4Emv88oRyw6NR+RouJM7XxXQ==",
       "dev": true
     },
     "@xtuc/ieee754": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "devDependencies": {
-    "@workadventure/iframe-api-typings": "^1.2.1",
+    "@workadventure/iframe-api-typings": "^1.4.0",
     "eslint": "^7.24.0",
     "html-webpack-plugin": "^5.3.1",
     "ts-loader": "^8.1.0",


### PR DESCRIPTION
This is needed otherwise TS build fails due to missing symbols